### PR TITLE
move the startup commands and parameters to the configuration file

### DIFF
--- a/computer-use-demo/computer_use_demo/loop.py
+++ b/computer-use-demo/computer_use_demo/loop.py
@@ -167,13 +167,13 @@ async def sampling_loop(
     Agentic sampling loop for the assistant/tool interaction of computer use.
     """
     try:
-        mcp_servers = evaluator.config.get("mcp_server_path", [])
+        mcp_servers = evaluator.config.get("mcp_servers", [])
     except:
         mcp_servers = []
     mcp_client = MCPClient()
     try:
-        for server_path in mcp_servers:
-            await mcp_client.connect_to_server(server_path)
+        for server in mcp_servers:
+            await mcp_client.connect_to_server(server)
 
         tool_group = TOOL_GROUPS_BY_VERSION[tool_version]
         tool_collection = ToolCollection(*(ToolCls() for ToolCls in tool_group.tools))

--- a/computer-use-demo/computer_use_demo/mcpclient.py
+++ b/computer-use-demo/computer_use_demo/mcpclient.py
@@ -11,21 +11,17 @@ class MCPClient:
         self.sessions: list[ClientSession] = []
         self.exit_stack = AsyncExitStack()
 
-    async def connect_to_server(self, server_script_path: str) -> None:
+    async def connect_to_server(self, server_start_option: dict) -> None:
         """Connect to an MCP server
 
-        Args:
-            server_script_path: Path to the server script (.py or .js)
+            Args:
+                server_start_option: Dictionary containing server start configuration, both `command` and `args`.
         """
-        is_python = server_script_path.endswith('.py')
-        is_js = server_script_path.endswith('.js')
-        if not (is_python or is_js):
-            raise ValueError("Server script must be a .py or .js file")
-
-        command = "python" if is_python else "node"
+        command = server_start_option.get('command')
+        args = server_start_option.get('args')
         server_params = StdioServerParameters(
             command=command,
-            args=[server_script_path],
+            args=args,
             env=None
         )
 


### PR DESCRIPTION
Since different MCP servers have different startup methods, we should transfer the startup command and parameter configuration to the configuration file to improve flexibility. For example, `vscode`, its mcp server startup method is: `mcp-proxy http://127.0.0.1:6010/sse`.