### PR TITLE
feat: add `cwd` for `mcp_servers`

### DIFF
--- a/agents/utils/connections.py
+++ b/agents/utils/connections.py
@@ -63,17 +63,18 @@ class MCPConnectionStdio(MCPConnection):
     """MCP connection using standard input/output."""
 
     def __init__(
-        self, command: str, args: list[str] = [], env: dict[str, str] = None
+        self, command: str, args: list[str] = [], env: dict[str, str] = None, cwd: str = None
     ):
         super().__init__()
         self.command = command
         self.args = args
         self.env = env
+        self.cwd = cwd
 
     async def _create_rw_context(self):
         return stdio_client(
             StdioServerParameters(
-                command=self.command, args=self.args, env=self.env
+                command=self.command, args=self.args, env=self.env, cwd=self.cwd
             )
         )
 
@@ -101,6 +102,7 @@ def create_mcp_connection(config: dict[str, Any]) -> MCPConnection:
             command=config["command"],
             args=config.get("args"),
             env=config.get("env"),
+            cwd=config.get("cwd"),
         )
 
     elif conn_type == "sse":

--- a/computer-use-demo/computer_use_demo/loop.py
+++ b/computer-use-demo/computer_use_demo/loop.py
@@ -195,7 +195,7 @@ async def sampling_loop(
                 betas.append("token-efficient-tools-2025-02-19")
             image_truncation_threshold = only_n_most_recent_images or 0
             if provider == APIProvider.ANTHROPIC:
-                client = Anthropic(api_key=api_key, max_retries=4, http_client=httpx.Client(proxy="http://10.109.246.210:10809"))
+                client = Anthropic(api_key=api_key, max_retries=4, http_client=httpx.Client(proxy="http://10.29.46.139:7890"))
                 enable_prompt_caching = True
             elif provider == APIProvider.VERTEX:
                 client = AnthropicVertex()

--- a/computer-use-demo/computer_use_demo/mcpclient.py
+++ b/computer-use-demo/computer_use_demo/mcpclient.py
@@ -20,7 +20,9 @@ class MCPClient:
         command = server_start_option.get('command')
         args = server_start_option.get('args')
         envs = server_start_option.get('env')
+        cwd = server_start_option.get('cwd')
         server_params = StdioServerParameters(
+            cwd=cwd,
             command=command,
             args=args,
             env=envs


### PR DESCRIPTION
## Description
<!-- Describe the changes you've made -->

Zotero's mcp server code requires specifying cwd when starting the mcp server. And I think this is useful for some configuration file paths that use relative paths.

## Quickstart
- [ ] Computer Use Demo
- [ ] Customer Support Agent
- [ ] Financial Data Analyst
- [ ] N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing
<!-- Describe the testing you've done -->
- [ ] Added/updated unit tests
- [x] Tested manually
- [x] Verified in development environment

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional context or notes about the changes -->